### PR TITLE
removes menu from renderemojiconfirmredirect

### DIFF
--- a/src/components/common/NavBar.js
+++ b/src/components/common/NavBar.js
@@ -40,10 +40,11 @@ const StyledNavBar = styled.header`
 `;
 
 function NavBar(props) {
-  const { userInfo, authService } = props;
+  const { hideMenu } = props;
   const context = useContext(UserContext);
+  const history = useHistory();
+
   let role = context.user.roles && context.user.roles[0].role.name;
-  console.log(role);
 
   const menu = (
     <Menu>
@@ -99,17 +100,19 @@ function NavBar(props) {
       </Menu.Item>
     </Menu>
   );
-  const history = useHistory();
+
   return (
     <>
       <StyledNavBar backgroundColor={props.backgroundColor}>
-        <div className="menu-container">
-          <Dropdown overlay={menu}>
-            <Button type="text" style={{ color: 'white', fontSize: '32px' }}>
-              <MenuOutlined />
-            </Button>
-          </Dropdown>
-        </div>
+        {!hideMenu && (
+          <div className="menu-container">
+            <Dropdown overlay={menu}>
+              <Button type="text" style={{ color: 'white', fontSize: '32px' }}>
+                <MenuOutlined />
+              </Button>
+            </Dropdown>
+          </div>
+        )}
         <h1>{props.titleName}</h1>
         <img src={logo} alt="Boys & Girls Club of Greater Conejo Valley" />
       </StyledNavBar>

--- a/src/components/pages/EmojiConfirmRedirect/RenderEmojiConfirmRedirect.js
+++ b/src/components/pages/EmojiConfirmRedirect/RenderEmojiConfirmRedirect.js
@@ -43,17 +43,15 @@ function RenderEmojiConfirmRedirect(props) {
   }, 4000);
 
   useEffect(() => {
-    console.log('context emoji: ', context.emoji);
     let selectedEmoji = emojiList.filter(emoji => {
       return context.emoji === emoji.id;
     });
-    console.log('selected: ', selectedEmoji);
     setState(selectedEmoji[0].component);
   }, [state]);
 
   return (
     <LayoutContainer>
-      <NavBar titleName="Dashboard" backgroundColor="#293845" />
+      <NavBar hideMenu />
       <StyledEmojiConfirmRedirect>
         <h2>Success!</h2>
         {state}

--- a/src/components/pages/EmojiSelectCheck/RenderEmojiSelectCheck.js
+++ b/src/components/pages/EmojiSelectCheck/RenderEmojiSelectCheck.js
@@ -83,7 +83,7 @@ function RenderEmojiSelectCheck(props) {
 
   return (
     <LayoutContainer>
-      <NavBar titleName="Dashboard" backgroundColor="#293845" />
+      <NavBar hideMenu />
       <StyledEmojiSelectCheck>
         <h2>Select Emoji</h2>
         {/* <Divider orientation="left">***</Divider> */}


### PR DESCRIPTION
# What's here (& what to consider)
* We don't want members selecting any options other than emojis.
* This will hide the menu button when members are on emoji selection screen and emoji confirmation screen.

# Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality) 
- [ ] This change requires a documentation update

# Change Status

- [ ] Complete, tested, ready to review, and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete / work-in-progress, PR is for discussion or feedback
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?

- [ ] Tested locally
- [ ] Test suite provides the same results as prior to making changes

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code# What's here (& what to consider)
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts


